### PR TITLE
Refactor: Display fighters in a single column

### DIFF
--- a/UFC_Front/src/App.js
+++ b/UFC_Front/src/App.js
@@ -12,7 +12,7 @@ function App() {
   }, []);
 
   return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', padding: '2rem' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '2rem' }}>
       {fighters.map(f => (
         <FighterCard key={f.id} fighter={f} />
       ))}


### PR DESCRIPTION
I've modified App.js to display the list of fighters in a single vertical column. This was achieved by changing the flexbox container's style from `flexWrap: 'wrap'` to `flexDirection: 'column'` and `alignItems: 'center'`.